### PR TITLE
Add XML namespace to math element in main.c

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -14,7 +14,7 @@ int main(int argc, char *argv[])
 		asprintf(&content, "%s%s", content, buffer);
 
 	char *result = amath_to_mathml(content);
-	printf("<math>%s</math>", result);
+	printf("<math xmlns=\"http://www.w3.org/1998/Math/MathML\">%s</math>", result);
 
 	if (strlen(result) > 0) free(result);
 	if (strlen(content) > 0) free(content);


### PR DESCRIPTION
The MathML XML namespace isn't needed in context of HTML5 (and I find it a bit verbose), but are used in other applications, e.g. LibreOffice's "[Import MathML from Clipboard](https://wiki.documentfoundation.org/ReleaseNotes/5.1#Import_MathML_from_Clipboard)". Probably should be an command line argument (default off?).
