### PR TITLE
Don't use mk_op_nosp for standard functions

### DIFF
--- a/src/amath.leg
+++ b/src/amath.leg
@@ -25,7 +25,7 @@ Start	= e0:Expr EOF	{ ((struct greg_data*) G->data)->result->text = strdup(e0->t
 
 Const	= < NUMBER >	{ $$ = mk_number(yytext); }
 	| Greek
-	| < STD >	{ $$ = mk_id(yytext); }
+	| < STD >	{ $$ = mk_op(yytext); }
 	| < SPECIAL >	{ $$ = mk_id(yytext); }
 	| Op
 	| < ID >	{ $$ = mk_id(yytext); }

--- a/src/amath.leg
+++ b/src/amath.leg
@@ -25,7 +25,7 @@ Start	= e0:Expr EOF	{ ((struct greg_data*) G->data)->result->text = strdup(e0->t
 
 Const	= < NUMBER >	{ $$ = mk_number(yytext); }
 	| Greek
-	| < STD >	{ $$ = mk_op_nosp(yytext); }
+	| < STD >	{ $$ = mk_id(yytext); }
 	| < SPECIAL >	{ $$ = mk_id(yytext); }
 	| Op
 	| < ID >	{ $$ = mk_id(yytext); }


### PR DESCRIPTION
I don't know why `mk_op_nosp` is currently used for standard functions but it turns `log x` into:

    <mo lspace="0" rspace="0">log</mo><mi>x</mi>

which gets rendered as `logx`.