### PR TITLE
Integrate official unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,19 @@ all: $(LIBRARY) $(BINARY)
 test:
 	@bash test/test.sh
 
+test/converter: test/converter.leg
+	leg test/converter.leg -o test/converter.c
+	$(CC) test/converter.c -o test/converter
+
+test/unittests.js:
+	wget 'https://raw.githubusercontent.com/asciimath/asciimathml/master/test/unittests.js' -O test/unittests.js
+
+test/official_tests.txt: test/unittests.js test/converter
+	test/converter < test/unittests.js > test/official_tests.txt
+
+otest: test/official_tests.txt
+	@bash test/official_tests.sh
+
 memory:
 	@bash test/memory.sh
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ The tests can be checked for memory leaks.
 
 	make memory
 
+The official AsciiMath unit tests can be run with:
+
+	make otest
+
 ## Legal
 
 This software is in the public domain. Anyone is free to use and

--- a/test/converter.leg
+++ b/test/converter.leg
@@ -1,0 +1,22 @@
+%{
+#include <stdio.h>
+%}
+
+# Parser to extract official unit tests from JavaScript into a line-based format.
+
+grammar = "{input:" - string - ',' { putchar('\n') } - "output:" - string { printf("\n\n") }
+	| .
+
+string = '"' strchr+  '"'
+
+strchr = !'"' '\\'? <.> { putchar(*yytext); }
+
+- = ' '*
+
+%%
+int main()
+{
+	while (yyparse())
+	;
+	return 0;
+}

--- a/test/official_tests.sh
+++ b/test/official_tests.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Run official unit tests.
+
+failed=0
+passed=0
+
+while read -r input; do
+	read -r expected
+	read -r _
+	got=$(build/amath <<< "$input")
+	
+	if [ "$got" != "$expected" ]; then
+		echo -e "\e[31m(FAIL)\e[0m $input"
+		echo "expected: $expected"
+		echo "got:      $got"
+		exit_status=1
+		failed=$((failed+1))
+	else
+		echo -e "\e[32m(PASS) $input"
+		passed=$((passed+1))
+	fi
+
+done < test/official_tests.txt
+
+echo "failed $failed, passed $passed"


### PR DESCRIPTION
While amath has some tests they are not extensive and I thought it would be nice if we could use the [432 official AsciiMath tests](https://github.com/asciimath/asciimathml/blob/master/test/unittests.js). So I wrote a small parser that extracts the unit tests from the JavaScript into a line-based format and an accompanying bash script to run the tests.